### PR TITLE
fix bulk-vouchers upload table reloading and fund pre-selection

### DIFF
--- a/react/src/dashboard/components/modals/ModalVouchersUpload.tsx
+++ b/react/src/dashboard/components/modals/ModalVouchersUpload.tsx
@@ -60,12 +60,14 @@ type RowDataProp = {
 export default function ModalVouchersUpload({
     funds,
     modal,
+    fundId,
     className,
     onCompleted,
     organization,
 }: {
     funds: Array<Partial<Fund>>;
     modal: ModalState;
+    fundId?: number;
     className?: string;
     onCompleted: () => void;
     organization: Organization;
@@ -102,7 +104,7 @@ export default function ModalVouchersUpload({
     const [availableFundsIds] = useState(funds.map((fund) => fund.id));
     const [availableFundsById] = useState(keyBy(funds, 'id'));
 
-    const [fund, setFund] = useState(funds[0]);
+    const [fund, setFund] = useState<Partial<Fund>>(funds?.find((fund) => fund.id == fundId) || funds[0]);
     const [step, setStep] = useState(STEP_SET_UP);
     const [progressBar, setProgressBar] = useState<number>(0);
     const [progressStatus, setProgressStatus] = useState<string>('');
@@ -1135,7 +1137,7 @@ export default function ModalVouchersUpload({
                                         type={'button'}
                                         className="button button-primary"
                                         disabled={loading}
-                                        onClick={modal.close}
+                                        onClick={closeModal}
                                         data-dusk="closeModalButton">
                                         Sluiten
                                     </button>

--- a/react/src/dashboard/components/pages/vouchers/elements/VouchersTableHeader.tsx
+++ b/react/src/dashboard/components/pages/vouchers/elements/VouchersTableHeader.tsx
@@ -49,9 +49,15 @@ export default function VouchersTableHeader({
     );
 
     const uploadVouchers = useCallback(
-        (funds: Array<Partial<Fund>>, onCreate?: () => void) => {
+        (funds: Array<Partial<Fund>>, fundId?: number, onCreate?: () => void) => {
             openModal((modal) => (
-                <ModalVouchersUpload modal={modal} funds={funds} organization={organization} onCompleted={onCreate} />
+                <ModalVouchersUpload
+                    modal={modal}
+                    fundId={fundId || funds[0].id}
+                    funds={funds}
+                    organization={organization}
+                    onCompleted={onCreate}
+                />
             ));
         },
         [openModal, organization],
@@ -83,7 +89,7 @@ export default function VouchersTableHeader({
                                     id="voucher_upload_csv"
                                     className="button button-primary"
                                     disabled={funds?.filter((fund) => fund.id)?.length < 1}
-                                    onClick={() => uploadVouchers(funds, fetchVouchers)}
+                                    onClick={() => uploadVouchers(funds, filter.activeValues?.fund_id, fetchVouchers)}
                                     data-dusk="uploadVouchersBatchButton">
                                     <em className="mdi mdi-upload icon-start" />
                                     {translate('vouchers.buttons.upload_csv')}


### PR DESCRIPTION
## Changes description & testing suggestions
- fixed reloading vouchers table after bulk upload is finished
- bulk upload modal will now preselect currently selected fund from table filters

<!---
Add tag if PR:
- [ ] *Needs Translations* @lexlog @irinaBerendeeva87
- [ ] *Could affect implementations custom css* @lexlog @irinaBerendeeva87
-->

## Developers checklist
- [x] *Check that dusk tests are working locally on compatible branch*
- [ ] *Mobile version of changes is developed* - if its a webshop feature, mobile version for this feature is developed

## QA checklist
- *Check regress in implementations custom css* - changes are not breaking other implementations designes
- Feature is tested in different screen sizes - desktop, mobile
- WCAG requirements are met - new feature is accessible by keyboard, there are an alt texts
- Translations are done
