### PR TITLE
revert react-router-dom to 6.27.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "react-gtm-module": "^2.0.11",
         "react-i18next": "^15.0.1",
         "react-image-crop": "^11.0.6",
-        "react-router-dom": "^7.0.1",
+        "react-router-dom": "^6.27.0",
         "summernote": "^0.9.1",
         "terser-webpack-plugin": "^5.3.9",
         "turndown": "^7.1.2",
@@ -2606,6 +2606,14 @@
       "integrity": "sha512-tieX9Va5w1yP88vMgfH1pHTacDQ9TgDTjox3tLlisKDXRQWdjw+QeVVghhf5XqqIxXHgPdcGwBvKY6UP+SIvLw==",
       "license": "MIT"
     },
+    "node_modules/@remix-run/router": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.21.0.tgz",
+      "integrity": "sha512-xfSkCAchbdG5PnbrKqFWwia4Bi61nH+wm8wLEqfHDyp7Y3dZzgqS2itV8i4gAq9pC2HsTpwyBC6Ds8VHZ96JlA==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -3139,12 +3147,6 @@
         "@types/express-serve-static-core": "*",
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
-      "license": "MIT"
     },
     "node_modules/@types/diff": {
       "version": "6.0.0",
@@ -11259,52 +11261,33 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.0.1.tgz",
-      "integrity": "sha512-WVAhv9oWCNsja5AkK6KLpXJDSJCQizOIyOd4vvB/+eHGbYx5vkhcmcmwWjQ9yqkRClogi+xjEg9fNEOd5EX/tw==",
-      "license": "MIT",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.28.0.tgz",
+      "integrity": "sha512-HrYdIFqdrnhDw0PqG/AKjAqEqM7AvxCz0DQ4h2W8k6nqmc5uRBYDag0SBxx9iYz5G8gnuNVLzUe13wl9eAsXXg==",
       "dependencies": {
-        "@types/cookie": "^0.6.0",
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0",
-        "turbo-stream": "2.4.0"
+        "@remix-run/router": "1.21.0"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        }
+        "react": ">=16.8"
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.0.1.tgz",
-      "integrity": "sha512-duBzwAAiIabhFPZfDjcYpJ+f08TMbPMETgq254GWne2NW1ZwRHhZLj7tpSp8KGb7JvZzlLcjGUnqLxpZQVEPng==",
-      "license": "MIT",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.28.0.tgz",
+      "integrity": "sha512-kQ7Unsl5YdyOltsPGl31zOjLrDv+m2VcIEcIHqYYD3Lp0UppLjrzcfJqDJwXxFw3TH/yvapbnUvPlAj7Kx5nbg==",
       "dependencies": {
-        "react-router": "7.0.1"
+        "@remix-run/router": "1.21.0",
+        "react-router": "6.28.0"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/react-router/node_modules/cookie": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
-      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/read-only-stream": {
@@ -12008,12 +11991,6 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "optional": true
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
-      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
-      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -13166,12 +13143,6 @@
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
       "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
       "dev": true
-    },
-    "node_modules/turbo-stream": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
-      "integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==",
-      "license": "ISC"
     },
     "node_modules/turndown": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "react-gtm-module": "^2.0.11",
     "react-i18next": "^15.0.1",
     "react-image-crop": "^11.0.6",
-    "react-router-dom": "^7.0.1",
+    "react-router-dom": "^6.27.0",
     "summernote": "^0.9.1",
     "terser-webpack-plugin": "^5.3.9",
     "turndown": "^7.1.2",

--- a/react/src/dashboard/components/pages/auth/IdentityRestore.tsx
+++ b/react/src/dashboard/components/pages/auth/IdentityRestore.tsx
@@ -74,7 +74,9 @@ export default function IdentityRestore({ confirmation = false }: { confirmation
     );
 
     useEffect(() => {
-        exchangeToken(token, target);
+        if (token) {
+            exchangeToken(token, target);
+        }
     }, [exchangeToken, token, target]);
 
     return <></>;

--- a/react/src/webshop/components/modals/ModalIdentityProxyExpired.tsx
+++ b/react/src/webshop/components/modals/ModalIdentityProxyExpired.tsx
@@ -44,7 +44,7 @@ export default function ModalIdentityProxyExpired({ modal }: { modal: ModalState
                         <h2 className="modal-section-title" role="heading" id="expiredIdentityDialogTitle">
                             {translate('expired_identity.title')}
                         </h2>
-                        <div className="description" id="expiredIdentityDialogDescription">
+                        <div className="modal-section-description" id="expiredIdentityDialogDescription">
                             {translate('expired_identity.description')}
                         </div>
                     </div>

--- a/react/src/webshop/components/pages/auth/IdentityRestore.tsx
+++ b/react/src/webshop/components/pages/auth/IdentityRestore.tsx
@@ -47,6 +47,7 @@ export default function IdentityRestore({ confirmation = false }: { confirmation
                 } else {
                     navigateState('start');
                 }
+
                 return true;
             }
 
@@ -102,7 +103,9 @@ export default function IdentityRestore({ confirmation = false }: { confirmation
     );
 
     useEffect(() => {
-        exchangeToken(token, target);
+        if (token) {
+            exchangeToken(token, target);
+        }
     }, [exchangeToken, token, target]);
 
     return <></>;


### PR DESCRIPTION
## Changes description & testing suggestions
Reverted react-router-dom upgraded in: [dependabot/npm_and_yarn/develop/react-router-dom-7.0.1](https://github.com/teamforus/forus-frontend-react/pull/479) because of some not so quick to fix breaking changes which broken functionality in at least 2 places (most likely more). 

<!---
Add tag if PR:
- [ ] *Needs Translations* @lexlog @irinaBerendeeva87
- [ ] *Could affect implementations custom css* @lexlog @irinaBerendeeva87
-->

## Developers checklist
- [ ] *Check that dusk tests are working locally on compatible branch*
- [ ] *Mobile version of changes is developed* - if its a webshop feature, mobile version for this feature is developed

## QA checklist
- *Check regress in implementations custom css* - changes are not breaking other implementations designes
- Feature is tested in different screen sizes - desktop, mobile
- WCAG requirements are met - new feature is accessible by keyboard, there are an alt texts
- Translations are done
