### PR TITLE
add number to product vouchers and upload transactions by voucher number

### DIFF
--- a/react/src/dashboard/i18n/i18n-nl.js
+++ b/react/src/dashboard/i18n/i18n-nl.js
@@ -1577,6 +1577,7 @@ export default {
     csv_upload: {
         buttons: {
             upload: 'Upload',
+            close: 'Sluiten',
         },
         labels: {
             swipe: 'Sleep hier het *.CSV of *.TXT bestand',

--- a/react/src/dashboard/services/TransactionService.ts
+++ b/react/src/dashboard/services/TransactionService.ts
@@ -54,8 +54,8 @@ export class TransactionService<T = Transaction> {
     }
 
     public sampleCsvTransactions() {
-        const headers = ['voucher_id', 'amount', 'direct_payment_iban', 'direct_payment_name', 'uid', 'note'];
-        const values = [1, 10, 'NLXXXXXXXXXXXXXXXX', 'XXXX XXXX', '', ''];
+        const headers = ['voucher_number', 'amount', 'direct_payment_iban', 'direct_payment_name', 'uid', 'note'];
+        const values = ['XXXXXXXX', 10, 'NLXXXXXXXXXXXXXXXX', 'XXXX XXXX', '', ''];
 
         return Papa.unparse([headers, values]);
     }


### PR DESCRIPTION
## Changes description & testing suggestions
All voucher types should now have a unique number.
Uploading transactions bulk should now use voucher_number instead of voucher_id.

<!---
Add tag if PR:
- [ ] *Needs Translations* @lexlog @irinaBerendeeva87
- [ ] *Could affect implementations custom css* @lexlog @irinaBerendeeva87
-->

## Developers checklist
- [ ] *Check that dusk tests are working locally on compatible branch*
- [ ] *Mobile version of changes is developed* - if its a webshop feature, mobile version for this feature is developed

## QA checklist
- *Check regress in implementations custom css* - changes are not breaking other implementations designes
- Feature is tested in different screen sizes - desktop, mobile
- WCAG requirements are met - new feature is accessible by keyboard, there are an alt texts
- Translations are done
