### PR TITLE
fix product reservation modal datepicker styles

### DIFF
--- a/react/src/dashboard/Dashboard.tsx
+++ b/react/src/dashboard/Dashboard.tsx
@@ -23,6 +23,7 @@ import ProviderNotificationProductRequired from './modules/provider_notification
 import { setDefaultOptions } from 'date-fns';
 import { nl } from 'date-fns/locale';
 import { ReactRouter7Adapter } from './modules/state_router/ReactRouter7Adapter';
+import 'react-datepicker/dist/react-datepicker.css';
 
 setDefaultOptions({ weekStartsOn: 1, locale: nl });
 

--- a/react/src/dashboard/components/pages/fund-requests/FundRequests.tsx
+++ b/react/src/dashboard/components/pages/fund-requests/FundRequests.tsx
@@ -7,7 +7,6 @@ import FilterItemToggle from '../../elements/tables/elements/FilterItemToggle';
 import SelectControl from '../../elements/select-control/SelectControl';
 import { useEmployeeService } from '../../../services/EmployeeService';
 import LoadingCard from '../../elements/loading-card/LoadingCard';
-import 'react-datepicker/dist/react-datepicker.css';
 import DatePickerControl from '../../elements/forms/controls/DatePickerControl';
 import { PaginationData } from '../../../props/ApiResponses';
 import useAppConfigs from '../../../hooks/useAppConfigs';

--- a/react/src/webshop/Webshop.tsx
+++ b/react/src/webshop/Webshop.tsx
@@ -35,6 +35,7 @@ import { isValidLocaleString } from '../dashboard/helpers/url';
 import { FrameDirectorProvider } from '../dashboard/modules/frame_director/context/FrameDirectorContext';
 import { LayoutProvider } from './contexts/LayoutContext';
 import { ReactRouter7Adapter } from '../dashboard/modules/state_router/ReactRouter7Adapter';
+import 'react-datepicker/dist/react-datepicker.css';
 
 const locale = localStorage.getItem('locale');
 


### PR DESCRIPTION
## Changes description & testing suggestions
Fix missing missing react-datepicker style from product reservation modal on webshops.

<!---
Add tag if PR:
- [ ] *Needs Translations* @lexlog @irinaBerendeeva87
- [ ] *Could affect implementations custom css* @lexlog @irinaBerendeeva87
-->

## Developers checklist
- [ ] *Check that dusk tests are working locally on compatible branch*
- [ ] *Mobile version of changes is developed* - if its a webshop feature, mobile version for this feature is developed

## QA checklist
- *Check regress in implementations custom css* - changes are not breaking other implementations designes
- Feature is tested in different screen sizes - desktop, mobile
- WCAG requirements are met - new feature is accessible by keyboard, there are an alt texts
- Translations are done
